### PR TITLE
맥에서 발생하는 오류 수정

### DIFF
--- a/distribution.json
+++ b/distribution.json
@@ -442,6 +442,9 @@
             "size": 341728,
             "url": "https://raw.githubusercontent.com/7days162/BeeServer-distributions/main/forgemods/optionalon/OreLib-1.12.2-3.6.0.1.jar",
             "MD5": "00cce3b240365458adcad3e77782358a"
+          },
+          "required": {
+            "value": false
           }
         },
         {


### PR DESCRIPTION
orelib의 중복 문제가 발생함과 동시에 이를 비필수 모드로 지정함으로서, 맥 사용자들이 해당 모드를 끄고 서버에 접속할 수 있도록 수정.